### PR TITLE
Fix duplicate api route declarations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -862,8 +862,8 @@ fastify.get('/health', async (request, reply) => {
   };
 });
 
-// API health check
-fastify.get('/api/health', async (request, reply) => {
+// API detailed health check (includes Firebase status)
+fastify.get('/api/health/detailed', async (request, reply) => {
   return { 
     status: 'healthy', 
     timestamp: new Date().toISOString(),
@@ -1106,7 +1106,7 @@ fastify.post('/api/support/handle', { preHandler: requireAdmin }, async (req, re
 });
 
 // Enhanced API endpoints for comprehensive admin panel
-fastify.get('/api/users', { preHandler: requireAdmin }, async (req, reply) => {
+fastify.get('/api/admin/users', { preHandler: requireAdmin }, async (req, reply) => {
   try {
     const usersSnapshot = await firestore.collection('users').get();
     const users = [];


### PR DESCRIPTION
Rename duplicate API routes to resolve `FST_ERR_DUPLICATED_ROUTE` errors.

This PR renames the admin-specific `/api/health` to `/api/health/detailed` and the admin-only `/api/users` to `/api/admin/users` to prevent conflicts with existing or future public routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad42fa96-34e8-4316-a882-d79ee2ffb77f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad42fa96-34e8-4316-a882-d79ee2ffb77f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

